### PR TITLE
Fixed compilation in VS, again.

### DIFF
--- a/csv_parser/csv_parser.h
+++ b/csv_parser/csv_parser.h
@@ -588,7 +588,7 @@ constexpr MatrixInformation Parser::parseToMatrixColumnMajor(std::string_view da
 				parsed_values.resize((column + 1) * rows);
 			}
 			using Number = typename Vector::value_type;
-			parsed_values[info.matrixIndex(row, column)] = readNumber<Number>(cell_data).template value_or(std::numeric_limits<Number>::quiet_NaN());
+			parsed_values[info.matrixIndex(row, column)] = readNumber<Number>(cell_data).value_or(std::numeric_limits<Number>::quiet_NaN());
 		}
 	);
 	std::swap(values, parsed_values);


### PR DESCRIPTION
A typo inside function `parseToMatrixRowMajor()` was fixed on Jun 7, 2022 (see [here](https://github.com/ashaduri/csv-parser/commit/29919e8c7ff6ddcd0d13316a562218ac88a60d49)), however, an identical typo in `parseToMatrixColumnMajor()` was overlooked.

This pull request applies the same fix to `parseToMatrixColumnMajor()`.
